### PR TITLE
Act as an app on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,9 @@
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <head>
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<!-- apple-web-mobile-web-app-capable tells iOS Safari that this is a web app. -->
+<meta name="apple-mobile-web-app-capable" content="yes" /><link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/site.webmanifest">


### PR DESCRIPTION
MobileSafari (the version of Safari on iOS/iPadOS) doesn’t read the web manifest like Android browsers do.

• declaring icon size in apple-touch-icon is not required if there’s only one icon size.
• added the apple web app tag, see inline comment